### PR TITLE
Improve Error::Message to hold almost any string

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::sync::OnceLock;
 
 pub(crate) static APP_NAME: OnceLock<String> = OnceLock::new();
@@ -9,7 +10,7 @@ pub(crate) static VERBOSE_ERRORS: bool = true;
 pub(crate) enum Error {
     Io(std::io::Error),
     Git(git2::Error),
-    Message(String),
+    Message(Cow<'static, str>),
 }
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
@@ -28,13 +29,13 @@ impl From<git2::Error> for Error {
 
 impl From<String> for Error {
     fn from(s: String) -> Self {
-        Self::Message(s)
+        Self::Message(s.into())
     }
 }
 
-impl From<&'_ str> for Error {
-    fn from(s: &str) -> Self {
-        Self::Message(s.to_string())
+impl From<&'static str> for Error {
+    fn from(s: &'static str) -> Self {
+        Self::Message(s.into())
     }
 }
 

--- a/src/git_utils.rs
+++ b/src/git_utils.rs
@@ -12,8 +12,8 @@ use crate::structs;
 pub(crate) fn process_current_dir(
     options: &structs::GetGitInfoOptions,
 ) -> Result<structs::OutputOptions> {
-    let git_dir_buf = git_subfolder(options)?
-        .ok_or_else(|| error::Error::Message("Not found .git folder".to_string()))?;
+    let git_dir_buf =
+        git_subfolder(options)?.ok_or_else(|| error::Error::from("Not found .git folder"))?;
 
     return process_repo(&git_dir_buf, options);
 }
@@ -28,10 +28,7 @@ fn git_subfolder(options: &structs::GetGitInfoOptions) -> Result<Option<path::Pa
         .unwrap_or_else(|| env::current_dir().map(Cow::from))?;
 
     if !path.exists() {
-        return Err(error::Error::Message(format!(
-            "Path '{}' doesn't exist",
-            path.display()
-        )));
+        return Err(format!("Path '{}' doesn't exist", path.display()).into());
     }
 
     for sub_path in path.ancestors() {


### PR DESCRIPTION
Now Error::Message is accepts owned string as well as borrowed static string without allocations.